### PR TITLE
Create Python Arena Point Generator

### DIFF
--- a/ArenaPointGenerator.py
+++ b/ArenaPointGenerator.py
@@ -1,0 +1,39 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.keys import Keys
+import json, requests, time
+
+username = input("What is your username?\n")
+password = input("What is your password?\n")
+
+chrome_options = Options()
+chrome_options.add_extension('./extension.crx')
+
+driver = webdriver.Chrome(options=chrome_options)
+
+driver.get('https://sso.prodigygame.com/game/login')
+driver.find_element_by_id("unauthenticated_game_login_form_username").send_keys(username)
+driver.find_element_by_id("unauthenticated_game_login_form_password").send_keys(password)
+driver.find_element_by_id("unauthenticated_game_login_form_password").send_keys(Keys.ENTER)
+time.sleep(30)
+
+token = driver.execute_script("return localStorage.JWT_TOKEN")
+userID = driver.execute_script("return _.player.userID")
+arenaseason = requests.get(f"https://api.prodigygame.com/leaderboard-api/user/{userID}/init?userID={userID}", headers={'Authorization': token})
+arenaseason = arenaseason.json()["seasonID"]
+driver.close()
+
+while True:
+    r = requests.post(f"https://api.prodigygame.com/leaderboard-api/season/{arenaseason}/user/{userID}/pvp?userID={userID}",
+        headers={
+            "authorization": token,
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "sec-fetch-mode": "cors",
+            "body": (f"seasonID={arenaseason}&action=win"),
+            "referrer": "https://play.prodigygame.com/",
+            "mode": "cors"
+        },
+        data=(f"seasonID={arenaseason}&action=win"),
+    )
+    print(f'{r.json()["points"]} (+100)')
+    time.sleep(61)


### PR DESCRIPTION
Using selenium and requests in python I was able to make a script to login to a prodigy account get the jwt token and userID of a player.

Then with that data the script makes post requests to https://api.prodigygame.com/leaderboard-api/season/{arenaseason}/user/{userID}/pvp?userID={userID}

userID being the id of the player and arenaseason being the season.

Here is a demo of the script:
<img width="84" alt="arenapoint example" src="https://user-images.githubusercontent.com/70211235/110517416-d46aea80-80d8-11eb-999c-569ab486b6ef.PNG">

After using it I got over 124,000 points still generating.

For it to work you will need the extension in the directory of the script.
This is so we can get the userID and as with out the extension prodigy does not allow selenium and will 404.